### PR TITLE
add support for nested default values

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+# default settings from the underlying image (quay.io/operator-framework/ansible-operator)
+roles_path = /opt/ansible/roles
+library = /usr/share/ansible/openshift
+
+# dictionaries defined in roles/microcks/default/main.yaml are merged
+# with the values from the microcks CR
+hash_behaviour = merge

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,3 +2,4 @@ FROM quay.io/operator-framework/ansible-operator:v0.5.0
 COPY k8s/ ${HOME}/k8s/
 COPY roles/ ${HOME}/roles/
 COPY watches.yaml ${HOME}/watches.yaml
+COPY ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
dictionaries defined in roles/microcks/default/main.yaml are merged with the values from the microcks CR